### PR TITLE
Implemented displaying and handling received friend requests

### DIFF
--- a/mobileClient/components/FriendsList.js
+++ b/mobileClient/components/FriendsList.js
@@ -42,15 +42,23 @@ export default class FriendsList extends React.Component {
         }
       })
       .then(response => {
-        const acceptedFriends = response.data.friends.filter(
-          friend => friend.status === "accepted"
+        // Ternary insanity
+        const {
+          acceptedFriends,
+          pendingFriends,
+          requestedFriends
+        } = response.data.friends.reduce(
+          (result, friend) =>
+            friend.status === "accepted"
+              ? (result.acceptedFriends.push(friend), result)
+              : friend.status === "pending"
+                ? (result.pendingFriends.push(friend), result)
+                : friend.status === "requested"
+                  ? (result.requestedFriends.push(friend), result)
+                  : result,
+          { acceptedFriends: [], pendingFriends: [], requestedFriends: [] }
         );
-        const pendingFriends = response.data.friends.filter(
-          friend => friend.status === "pending"
-        );
-        const requestedFriends = response.data.friends.filter(
-          friend => friend.status === "requested"
-        );
+
         this.setState({
           acceptedFriends,
           pendingFriends,

--- a/mobileClient/components/FriendsList.js
+++ b/mobileClient/components/FriendsList.js
@@ -172,7 +172,7 @@ export default class FriendsList extends React.Component {
                   <ListItem
                     roundAvatar
                     title={`${item.friend.username}`}
-                    subtitle="Pending Friend Request"
+                    subtitle="Friend Request Received"
                     avatar={{ uri: item.friend.avatarUrl }}
                     containerStyle={{ borderBottomWidth: 0 }}
                     leftIcon={{ name: "thumb-up" }}

--- a/mobileClient/components/FriendsList.js
+++ b/mobileClient/components/FriendsList.js
@@ -1,36 +1,109 @@
 import React from "react";
-import { StyleSheet, Text, View, TextInput, Button, FlatList, AsyncStorage } from "react-native";
+import {
+  StyleSheet,
+  Text,
+  View,
+  TextInput,
+  SectionList,
+  AsyncStorage,
+  ActivityIndicator
+} from "react-native";
 import axios from "axios";
-import { localip } from 'react-native-dotenv';
-import { List, ListItem, SearchBar } from "react-native-elements";
+import { localip } from "react-native-dotenv";
+import { List, ListItem, SearchBar, Button, h1 } from "react-native-elements";
 
 export default class FriendsList extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      token: '',
-      friends: []
+      token: "",
+      acceptedFriends: [],
+      requestedFriends: [],
+      pendingFriends: [],
+      refreshing: false,
+      loading: false
     };
   }
 
   // call our api to get the users apis
   // set result to state
   async componentDidMount() {
-    const token = await AsyncStorage.getItem("jwt");
+    this.setState({ token: await AsyncStorage.getItem("jwt") });
+    this.getFriendData();
+  }
+
+  getFriendData = async () => {
+    this.setState({ loading: true });
+
     axios
       .get(`http://${localip}:3000/getfriends`, {
         headers: {
-          Authorization: token
+          Authorization: this.state.token
         }
       })
       .then(response => {
-        this.setState({ friends: response.data });
+        const acceptedFriends = response.data.friends.filter(
+          friend => friend.status === "accepted"
+        );
+        const pendingFriends = response.data.friends.filter(
+          friend => friend.status === "pending"
+        );
+        const requestedFriends = response.data.friends.filter(
+          friend => friend.status === "requested"
+        );
+        this.setState({
+          acceptedFriends,
+          pendingFriends,
+          requestedFriends,
+          loading: false,
+          refreshing: false
+        });
       })
       .catch(error => {
         console.log(error);
       });
-  }
+  };
 
+  acceptFriendRequest = async friend => {
+    await axios.post(
+      `http://${localip}:3000/addfriend`,
+      { friendId: friend._id },
+      {
+        headers: {
+          Authorization: this.state.token,
+          "Content-Type": "application/json"
+        }
+      }
+    );
+
+    this.getFriendData();
+  };
+
+  rejectFriendRequest = async friend => {
+    await axios.post(
+      `http://${localip}:3000/removefriend`,
+      { friendId: friend._id },
+      {
+        headers: {
+          Authorization: this.state.token,
+          "Content-Type": "application/json"
+        }
+      }
+    );
+
+    this.getFriendData();
+  };
+
+  handleRefresh = () => {
+    this.setState(
+      {
+        refreshing: true
+      },
+      () => {
+        this.getFriendData();
+      }
+    );
+  };
 
   renderSeparator = () => {
     return (
@@ -65,29 +138,91 @@ export default class FriendsList extends React.Component {
     );
   };
 
+  renderSectionHeader = section => {
+    if (section.data.length) {
+      return (
+        <View>
+          <Text h1>{section.key}</Text>
+        </View>
+      );
+    }
+    return null;
+  };
+
   render() {
     return (
-        <List containerStyle={{ borderTopWidth: 0, borderBottomWidth: 0 }}>
-          <FlatList
-            data={this.state.friends}
-            renderItem={({ item }) => (
-              <ListItem
-                roundAvatar
-                title={`${item.username}`}
-                avatar={{ uri: item.avatarUrl }}
-                containerStyle={{ borderBottomWidth: 0 }}
-              />
-            )}
-            keyExtractor={item => item._id}
-            ItemSeparatorComponent={this.renderSeparator}
-            ListHeaderComponent={this.renderHeader}
-            ListFooterComponent={this.renderFooter}
-            // onRefresh={this.handleRefresh}
-            // refreshing={this.state.refreshing}
-            // onEndReached={this.handleLoadMore}
-            // onEndReachedThreshold={50}
-          />
-        </List>
+      <List containerStyle={{ borderTopWidth: 0, borderBottomWidth: 0 }}>
+        <SectionList
+          keyExtractor={item => item._id}
+          ItemSeparatorComponent={this.renderSeparator}
+          SectionSeparatorComponent={this.renderSeparator}
+          ListHeaderComponent={this.renderHeader}
+          ListFooterComponent={this.renderFooter}
+          onRefresh={this.handleRefresh}
+          refreshing={this.state.refreshing}
+          renderSectionHeader={({ section }) =>
+            this.renderSectionHeader(section)
+          }
+          sections={[
+            {
+              data: this.state.pendingFriends,
+              key: "Friend Requests",
+              renderItem: ({ item }) => {
+                return (
+                  <ListItem
+                    roundAvatar
+                    title={`${item.friend.username}`}
+                    subtitle="Pending Friend Request"
+                    avatar={{ uri: item.friend.avatarUrl }}
+                    containerStyle={{ borderBottomWidth: 0 }}
+                    leftIcon={{ name: "thumb-up" }}
+                    leftIconOnPress={() => {
+                      this.acceptFriendRequest(item);
+                    }}
+                    rightIcon={{ name: "thumb-down" }}
+                    onPressRightIcon={() => {
+                      this.rejectFriendRequest(item);
+                    }}
+                  />
+                );
+              }
+            },
+            {
+              data: this.state.requestedFriends,
+              key: "Sent Friend Requests",
+              renderItem: ({ item }) => {
+                return (
+                  <ListItem
+                    roundAvatar
+                    title={`${item.friend.username}`}
+                    subtitle="Friend Request Sent"
+                    avatar={{ uri: item.friend.avatarUrl }}
+                    containerStyle={{ borderBottomWidth: 0 }}
+                    rightIcon={{ name: "thumb-down" }}
+                    onPressRightIcon={() => {
+                      this.rejectFriendRequest(item);
+                    }}
+                  />
+                );
+              }
+            },
+            {
+              data: this.state.acceptedFriends,
+              key: "Friends",
+              renderItem: ({ item }) => {
+                return (
+                  <ListItem
+                    roundAvatar
+                    title={`${item.friend.username}`}
+                    avatar={{ uri: item.friend.avatarUrl }}
+                    containerStyle={{ borderBottomWidth: 0 }}
+                  />
+                );
+              }
+            }
+          ]}
+        />
+      </List>
     );
   }
 }

--- a/mobileClient/package.json
+++ b/mobileClient/package.json
@@ -8,6 +8,7 @@
     "react-native": "https://github.com/expo/react-native/archive/sdk-25.0.0.tar.gz",
     "react-native-dotenv": "^0.1.1",
     "react-native-elements": "^0.19.0",
+    "react-native-modal": "^5.0.0",
     "react-navigation": "^1.0.0"
   }
 }

--- a/mobileClient/yarn.lock
+++ b/mobileClient/yarn.lock
@@ -3024,7 +3024,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0:
+prop-types@15.6.0, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -3099,6 +3099,12 @@ react-devtools-core@3.0.0:
     shell-quote "^1.6.1"
     ws "^2.0.3"
 
+react-native-animatable@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/react-native-animatable/-/react-native-animatable-1.2.4.tgz#b5fb7657e8f6edadbc26697057a327fb920b3039"
+  dependencies:
+    prop-types "^15.5.10"
+
 react-native-branch@2.0.0-beta.3:
   version "2.0.0-beta.3"
   resolved "https://registry.yarnpkg.com/react-native-branch/-/react-native-branch-2.0.0-beta.3.tgz#2167af86bbc9f964bd45bd5f37684e5b54965e32"
@@ -3145,6 +3151,13 @@ react-native-gesture-handler@1.0.0-alpha.39:
 react-native-maps@0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-0.19.0.tgz#ce94fad1cf360e335cb4338a68c95f791e869074"
+
+react-native-modal@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-5.0.0.tgz#d9a056e68a985678d9545fce38dcc1ac3299ba31"
+  dependencies:
+    prop-types "15.6.0"
+    react-native-animatable "^1.2.4"
 
 react-native-safe-module@^1.1.0:
   version "1.2.0"

--- a/server/controllers/coin.js
+++ b/server/controllers/coin.js
@@ -175,7 +175,9 @@ const getWalletInfo = async (coin, address) => {
       process.env.infura_API_key
     );
 
-    result.data.balance = utils.formatEther(await provider.getBalance(address));
+    result.data.balance = parseFloat(
+      utils.formatEther(await provider.getBalance(address))
+    );
     return result;
   } else if (coin === "eth_test") {
     const result = {
@@ -188,7 +190,9 @@ const getWalletInfo = async (coin, address) => {
       process.env.infura_API_key
     );
 
-    result.data.balance = utils.formatEther(await provider.getBalance(address));
+    result.data.balance = parseFloat(
+      utils.formatEther(await provider.getBalance(address))
+    );
     return result;
   } else {
     return { success: true, error: "invalid coin given" };

--- a/server/controllers/user.js
+++ b/server/controllers/user.js
@@ -56,10 +56,6 @@ const getFriends = async (req, res) => {
       });
     }
 
-    fships.sort(
-      (a, b) => (a.status > b.status ? 1 : b.status > a.status ? -1 : 0)
-    );
-
     res.json({ success: true, friends: fships });
   });
 };

--- a/server/controllers/user.js
+++ b/server/controllers/user.js
@@ -1,4 +1,5 @@
 const User = require("../models/user");
+const Status = require("mongoose-friends").Status;
 const ObjectId = require("mongodb").ObjectId; // somewhere we need to place the instantiation of the ObjectId function
 const CoinController = require("./coin");
 
@@ -20,6 +21,17 @@ const createUser = async (req, res) => {
   }
 };
 
+const getAllUsers = async (req, res) => {
+  try {
+    const users = await User.find({});
+    res.json({ success: true, users });
+  } catch (error) {
+    return res.json({
+      error: { success: false, message: "Something went wrong on the server" }
+    });
+  }
+};
+
 const getUserInfo = async (req, res) => {
   try {
     const user = await User.findById(req.user.id);
@@ -36,11 +48,20 @@ const getUserInfo = async (req, res) => {
 };
 
 const getFriends = async (req, res) => {
-  User.findOne({ _id: ObjectId(req.user.id) })
-    .populate({ path: "friends", select: ["username", "avatarUrl", "_id"] })
-    .exec()
-    .then(results => res.json(results.friends))
-    .catch(err => res.json(err));
+  User.getFriends(req.user, (err, fships) => {
+    if (err) {
+      return res.json({
+        success: false,
+        message: "Something went wrong on the server"
+      });
+    }
+
+    fships.sort(
+      (a, b) => (a.status > b.status ? 1 : b.status > a.status ? -1 : 0)
+    );
+
+    res.json({ success: true, friends: fships });
+  });
 };
 
 const getWallets = async (req, res) => {
@@ -49,62 +70,53 @@ const getWallets = async (req, res) => {
 
     for (let i = 0; i < user.wallets.length; i++) {
       const wallet = user.wallets[i];
-      const walletData = await CoinController.getWalletInfo(wallet.coinAbbr, wallet.address);
+      const walletData = await CoinController.getWalletInfo(
+        wallet.coinAbbr,
+        wallet.address
+      );
 
       user.wallets[i].balance = walletData.data.balance;
     }
-    res.json({ succes: true, wallets: user.wallets });
+    res.json({ success: true, wallets: user.wallets });
   } catch (error) {
-    res.json({ succes: false, message: error.message });
+    res.json({ success: false, message: error.message });
   }
 };
 
-const addFriend = (req, res) => {
-  const { userId1, userId2 } = req.body;
-
-  // add the second user (userId2) to first users (userId1) friend list
-  User.findOneAndUpdate(
-    { _id: ObjectId(userId1) },
-    { $addToSet: { friends: ObjectId(userId2) } }
-  )
-    .then(() => {
-      // add the first user (userId1) to second users (userId2) friend list
-      User.findOneAndUpdate(
-        { _id: ObjectId(userId2) },
-        { $addToSet: { friends: ObjectId(userId1) } }
-      )
-        .then(() =>
-          res.json({ success: true, message: "successfully added friend" })
-        )
-        .catch(err1 => res.json(err1));
-    })
-    .catch(err => res.json(err));
+const addFriend = async (req, res) => {
+  const { friendId } = req.body;
+  const newFriend = await User.findById(friendId);
+  User.requestFriend(req.user, newFriend, err => {
+    if (err) {
+      console.log(err);
+      return res.json({
+        success: false,
+        message: "Something went wrong on the server"
+      });
+    }
+    res.json({ success: true, message: "Friend request sent" });
+  });
 };
 
-const removeFriend = (req, res) => {
-  const { userId1, userId2 } = req.body;
+const removeFriend = async (req, res) => {
+  const { friendId } = req.body;
 
-  // remove the second user (userId2) from first users (userId1) friend list
-  User.findOneAndUpdate(
-    { _id: ObjectId(userId1) },
-    { $pull: { friends: ObjectId(userId2) } }
-  )
-    .then(() => {
-      // remove the first user (userId1) from second users (userId2) friend list
-      User.findOneAndUpdate(
-        { _id: ObjectId(userId2) },
-        { $pull: { friends: ObjectId(userId1) } }
-      )
-        .then(() =>
-          res.json({ success: true, message: "successfully removed friend" })
-        )
-        .catch(err1 => res.json(err1));
-    })
-    .catch(err => res.json(err));
+  const delFriend = await User.findById(friendId);
+
+  User.removeFriend(req.user, delFriend, err => {
+    if (err) {
+      return res.json({
+        success: false,
+        message: "Something went wrong on the server"
+      });
+    }
+    res.json({ success: true, message: "Friend removed" });
+  });
 };
 
 module.exports = {
   createUser,
+  getAllUsers,
   getFriends,
   getWallets,
   addFriend,

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const friends = require('mongoose-friends');
 const Schema = mongoose.Schema;
 const bcrypt = require("bcryptjs");
 
@@ -21,11 +22,11 @@ const UserSchema = new Schema({
     type: String,
     unique: true
   },
-  friends: {
-    type: [{ type: Schema.Types.ObjectId, ref: 'User' }],
-    default: [],
-    required: true
-  },
+  // friends: {
+  //   type: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+  //   default: [],
+  //   required: true
+  // },
   wallets: {
     type: Array,
     required: true,
@@ -37,6 +38,8 @@ const UserSchema = new Schema({
     default: "https://impactspace.com/images/uploads/person-default.png"
   }
 });
+
+UserSchema.plugin(friends());
 
 UserSchema.pre("save", async function(next) {
   try {

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
     "keythereum": "^1.0.2",
     "moment": "^2.20.1",
     "mongoose": "^5.0.2",
+    "mongoose-friends": "^0.2.5",
     "passport": "^0.4.0",
     "passport-jwt": "^3.0.1",
     "passport-local": "^1.0.0"

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -24,9 +24,12 @@ module.exports = app => {
   app
     .route("/getwallets") // takes in <coin> and <address> params as query params
     .get(authController.requireAuth, userController.getWallets);
-    
+
   // Route to test Auth, can be removed if needed
   app
     .route("/user")
     .get(authController.requireAuth, userController.getUserInfo);
+  app
+    .route("/users")
+    .get(authController.requireAuth, userController.getAllUsers);
 };

--- a/server/server.js
+++ b/server/server.js
@@ -2,6 +2,7 @@ const express = require("express");
 const bodyParser = require("body-parser");
 const mongoose = require("mongoose");
 const passport = require("passport");
+const cors = require("cors");
 
 const routes = require("./routes/routes");
 
@@ -14,6 +15,7 @@ const port = process.env.PORT || 3000;
 
 const app = express();
 
+app.use(cors());
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(passport.initialize());

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -108,6 +108,10 @@ async@2.1.4:
   dependencies:
     lodash "^4.14.0"
 
+async@~0.2.9:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -1581,6 +1585,12 @@ mongodb@3.0.1:
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.0.1.tgz#278ee8006257ec22798594a6259546825d6de1b2"
   dependencies:
     mongodb-core "3.0.1"
+
+mongoose-friends@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/mongoose-friends/-/mongoose-friends-0.2.5.tgz#82263537cdf953565b6c6aa3722c633f87779a3b"
+  dependencies:
+    async "~0.2.9"
 
 mongoose-legacy-pluralize@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Updated backend to use Mongoose-Friends plugin.

Split friends list into Pending Friends, Sent Friend Requests, and Friends, There might be a better way to handle getting each friend type, but for now it is working. I filtered the friends by status on the frontend and separated them into different arrays, I figured hitting the DB once and then filtering the results would be better than hitting the DB once for each friend status.

I didn't do any styling, so it definitely needs that.

Also cast the Ethereum balances to a float.